### PR TITLE
feat(docs): OpenAPI 3.0 spec + Scalar API reference at /docs

### DIFF
--- a/mei-next/app/docs/route.ts
+++ b/mei-next/app/docs/route.ts
@@ -1,0 +1,35 @@
+export const runtime = "nodejs";
+export const dynamic = "force-static";
+
+/**
+ * GET /docs — Scalar API Reference UI, loading the spec from /openapi.json.
+ * The Scalar bundle is loaded from a PINNED jsDelivr version with Subresource
+ * Integrity (sha384) + crossorigin, so a CDN compromise cannot substitute the
+ * script (hash mismatch -> the browser refuses to execute it).
+ */
+const SCALAR_SRC = "https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.59.2/dist/browser/standalone.js";
+const SCALAR_SRI = "sha384-qdTNFfkRv/L0BHDvwW9XzQxu3rtN4r41Oun6L7siNlsqDTGlEKX1MYgNfNoRZ4Qg";
+
+const HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MIE API (v2) — Reference</title>
+    <link rel="icon" href="data:," />
+  </head>
+  <body>
+    <script
+      id="api-reference"
+      data-url="/openapi.json"
+      data-configuration='{"theme":"purple","layout":"modern"}'
+    ></script>
+    <script src="${SCALAR_SRC}" integrity="${SCALAR_SRI}" crossorigin="anonymous"></script>
+  </body>
+</html>`;
+
+export async function GET() {
+  return new Response(HTML, {
+    headers: { "content-type": "text/html; charset=utf-8" },
+  });
+}

--- a/mei-next/app/openapi.json/route.ts
+++ b/mei-next/app/openapi.json/route.ts
@@ -1,0 +1,16 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { buildOpenApiSpec } from "@/lib/openapi/spec";
+
+/**
+ * GET /openapi.json — the OpenAPI 3.0 document for the v2 API.
+ * `servers` is set from the request origin so "Try it out" targets this same
+ * deployment (preview, prod, or a custom domain). Not enveloped.
+ */
+export async function GET(req: Request) {
+  const origin = new URL(req.url).origin;
+  return Response.json(buildOpenApiSpec(origin), {
+    headers: { "cache-control": "public, max-age=300" },
+  });
+}

--- a/mei-next/lib/openapi/schemas.ts
+++ b/mei-next/lib/openapi/schemas.ts
@@ -1,0 +1,471 @@
+/**
+ * OpenAPI 3.0 component schemas for the v2 wire contract (see
+ * ../../../nextjs-migration/schema.md). Hand-authored to mirror the serializers,
+ * including the deliberate quirks (chapaterLabel, stopped_reading, +00:00 dates,
+ * enum values on the wire). Plain data — consumed by lib/openapi/spec.ts.
+ */
+
+type Schema = Record<string, unknown>;
+
+const str: Schema = { type: "string" };
+const strN: Schema = { type: "string", nullable: true };
+const int: Schema = { type: "integer" };
+const intN: Schema = { type: "integer", nullable: true };
+const num: Schema = { type: "number" };
+const boolean: Schema = { type: "boolean" };
+const dateStr: Schema = { type: "string", description: "ISO-8601 UTC (+00:00 offset)" };
+const dateStrN: Schema = { type: "string", nullable: true, description: "ISO-8601 UTC (+00:00 offset)" };
+const strArrN: Schema = { type: "array", items: { type: "string" }, nullable: true };
+
+const arr = (items: Schema): Schema => ({ type: "array", items });
+const obj = (properties: Record<string, Schema>, required?: string[]): Schema => ({
+  type: "object",
+  properties,
+  ...(required && required.length ? { required } : {}),
+});
+const ref = (n: string): Schema => ({ $ref: `#/components/schemas/${n}` });
+const enumStr = (...values: string[]): Schema => ({ type: "string", enum: values });
+const enumStrN = (...values: string[]): Schema => ({ type: "string", enum: values, nullable: true });
+
+const targetType: Schema = enumStr("book", "chapter", "page");
+const accessType: Schema = enumStrN("free", "subscription", "paid");
+
+export const securitySchemes: Record<string, Schema> = {
+  bearerAuth: {
+    type: "http",
+    scheme: "bearer",
+    bearerFormat: "JWT",
+    description:
+      "Stateful JWT. Send `Authorization: Bearer <accessToken>`. The token's inner id must resolve to a live accessToken row (< 10 days; admins must be activated).",
+  },
+};
+
+export const schemas: Record<string, Schema> = {
+  // -- envelopes / pagination ------------------------------------------------
+  ErrorEnvelope: obj(
+    {
+      success: { type: "boolean", enum: [false] },
+      message: str,
+      data: { nullable: true },
+      errors: { nullable: true, description: "Present only for structured errors (e.g. 422)." },
+    },
+    ["success", "message", "data"],
+  ),
+  ListMeta: obj(
+    { skip: int, limit: int, returned: int, total: int, hasMore: boolean },
+    ["skip", "limit", "returned", "total", "hasMore"],
+  ),
+  ListSummary: obj({ totalItems: int, returnedItems: int }, ["totalItems", "returnedItems"]),
+  MessageOut: obj({ message: str }, ["message"]),
+  DeletedOut: obj({ deleted: { type: "boolean", enum: [true] } }, ["deleted"]),
+  HealthOut: obj({ status: enumStr("healthy") }, ["status"]),
+  WebhookResultOut: obj({
+    status: enumStr("fulfilled", "idempotent_replay"),
+    txRef: strN,
+    provider: strN,
+  }),
+
+  // -- summaries (embedded) --------------------------------------------------
+  ChapterSummary: obj(
+    {
+      id: str,
+      bookId: strN,
+      chapterLabel: strN,
+      number: intN,
+      accessType,
+      coverImage: strN,
+      pageCount: intN,
+      dateCreated: dateStrN,
+      dateUpdated: dateStrN,
+    },
+    ["id"],
+  ),
+  PageSummary: obj(
+    { id: str, chapterId: strN, status: strN, number: intN, textCount: intN, dateCreated: dateStrN, dateUpdated: dateStrN },
+    ["id"],
+  ),
+  BookSummary: obj(
+    { id: str, name: strN, number: intN, chapterCount: intN, dateCreated: dateStrN, dateUpdated: dateStrN },
+    ["id"],
+  ),
+
+  // -- content ---------------------------------------------------------------
+  BookOut: obj(
+    {
+      name: str,
+      number: int,
+      dateCreated: dateStrN,
+      dateUpdated: dateStrN,
+      chapterCount: intN,
+      chapters: strArrN,
+      id: strN,
+      lastAccessed: dateStr,
+    },
+    ["name", "number"],
+  ),
+  ChapterOut: obj(
+    {
+      bookId: str,
+      chapterLabel: strN,
+      status: strN,
+      accessType,
+      unlockBundleId: strN,
+      number: intN,
+      id: strN,
+      coverImage: strN,
+      lastAccessed: dateStrN,
+      dateCreated: dateStrN,
+      dateUpdated: dateStrN,
+      pageCount: intN,
+      pages: strArrN,
+      commentsCount: intN,
+      likesCount: intN,
+    },
+    ["bookId"],
+  ),
+  ChapterOutSync: obj(
+    { bookId: str, chapterLabel: strN, accessType, number: intN, id: strN, hasRead: boolean },
+    ["bookId", "hasRead"],
+  ),
+  PageOut: obj(
+    {
+      chapterId: str,
+      textContent: str,
+      status: str,
+      dateCreated: dateStrN,
+      dateUpdated: dateStrN,
+      textCount: intN,
+      id: strN,
+      lastAccessed: dateStrN,
+    },
+    ["chapterId", "textContent", "status"],
+  ),
+
+  // -- user ------------------------------------------------------------------
+  Stage: obj({ currentStage: int, currentExperience: int }, ["currentStage", "currentExperience"]),
+  SubscriptionInfo: obj({ active: boolean, expiresAt: strN }, ["active"]),
+  ReadingHistory: obj({ chapterId: strN, chapterNumber: intN, chapterSnippet: strN }),
+  UserOut: obj(
+    {
+      userId: strN,
+      status: enumStrN("Active", "Inactive", "Suspended"),
+      email: str,
+      firstName: strN,
+      lastName: strN,
+      avatar: strN,
+      accessToken: strN,
+      refreshToken: strN,
+      balance: intN,
+      unlockedChapters: strArrN,
+      dateCreated: dateStrN,
+      stage: ref("Stage"),
+      bookmarks: arr(ref("BookMarkOut")),
+      likes: arr(ref("LikeOut")),
+      stopped_reading: { ...ref("ReadingHistory"), nullable: true, description: "snake_case key (legacy quirk)" } as Schema,
+      authProviders: arr(str),
+      subscription: ref("SubscriptionInfo"),
+    },
+    ["email"],
+  ),
+  NewUserOut: obj(
+    {
+      userId: strN,
+      email: str,
+      balance: intN,
+      accessToken: strN,
+      refreshToken: strN,
+      unlockedChapters: strArrN,
+      firstName: strN,
+      lastName: strN,
+      avatar: strN,
+      dateCreated: dateStrN,
+      stage: ref("Stage"),
+      bookmarks: arr(ref("BookMarkOut")),
+      likes: arr(ref("LikeOut")),
+      stopped_reading: { ...ref("ReadingHistory"), nullable: true } as Schema,
+      authProviders: arr(str),
+      subscription: ref("SubscriptionInfo"),
+    },
+    ["email"],
+  ),
+  OldUserOut: {
+    allOf: [ref("NewUserOut")],
+    description: "Like NewUserOut but accessToken and refreshToken are non-null.",
+  },
+  UserOutChapterDetails: {
+    allOf: [ref("UserOut"), obj({ chapterDetails: arr(ref("ChapterOutSync")) })],
+  },
+  UserDetailsV2Out: obj(
+    {
+      userId: str,
+      email: str,
+      firstName: strN,
+      lastName: strN,
+      avatar: strN,
+      summary: obj({ totalLikes: int, totalBookmarks: int }, ["totalLikes", "totalBookmarks"]),
+      likes: arr(obj({ index: int, item: ref("LikeOut") }, ["index", "item"])),
+      bookmarks: arr(obj({ index: int, item: ref("BookMarkOut") }, ["index", "item"])),
+      readingProgress: { ...ref("ReadingProgressOut"), nullable: true } as Schema,
+      likesMeta: ref("ListMeta"),
+      bookmarksMeta: ref("ListMeta"),
+    },
+    ["userId", "email"],
+  ),
+  TokenRefreshOut: obj(
+    { userId: str, dateCreated: dateStr, refreshToken: str, accessToken: str },
+    ["userId", "refreshToken", "accessToken"],
+  ),
+
+  // -- interactions ----------------------------------------------------------
+  CommentOut: obj(
+    {
+      id: strN,
+      userId: str,
+      role: str,
+      text: str,
+      targetType,
+      targetId: str,
+      parentCommentId: strN,
+      commentType: enumStrN("reply_target", "Reply To Chapter", "Reply To Comment", "Reply To Reply"),
+      dateCreated: dateStrN,
+      firstName: strN,
+      lastName: strN,
+      avatar: strN,
+      email: strN,
+    },
+    ["userId", "role", "text", "targetType", "targetId"],
+  ),
+  LikeOut: obj(
+    {
+      chapterId: str,
+      userId: str,
+      role: str,
+      likeType: enumStrN("Liked Chapter", "Liked Comment", "Liked Comment Reply", "Liked Reply To Reply"),
+      chapaterLabel: { type: "string", description: "Misspelled on purpose (legacy wire field)." },
+      dateCreated: dateStrN,
+      id: strN,
+      chapterSummary: { ...ref("ChapterSummary"), nullable: true } as Schema,
+    },
+    ["chapterId", "userId", "role", "chapaterLabel"],
+  ),
+  LikeWithUserOut: {
+    allOf: [
+      ref("LikeOut"),
+      obj({ user: { ...obj({ firstName: strN, lastName: strN, avatar: strN, email: strN }), nullable: true } as Schema }),
+    ],
+  },
+  BookMarkOut: obj(
+    {
+      userId: str,
+      targetType,
+      targetId: str,
+      chapterLabel: strN,
+      chapterId: strN,
+      pageId: strN,
+      dateCreated: dateStrN,
+      id: strN,
+      pageNumber: intN,
+      chapterSummary: { ...ref("ChapterSummary"), nullable: true } as Schema,
+    },
+    ["userId", "targetType", "targetId"],
+  ),
+  ReactionOut: obj(
+    { reaction: str, authorRoomId: str, id: strN, dateCreated: dateStrN, lastUpdated: dateStrN },
+    ["reaction", "authorRoomId"],
+  ),
+  AuthorRoomOut: obj(
+    {
+      text: str,
+      chapterId: str,
+      id: strN,
+      dateCreated: dateStrN,
+      lastUpdated: dateStrN,
+      chapterSummary: { ...ref("ChapterSummary"), nullable: true } as Schema,
+      reactionSummary: { type: "object", additionalProperties: { type: "integer" } },
+      userReaction: strN,
+    },
+    ["text", "chapterId"],
+  ),
+  ReadingProgressOut: obj(
+    {
+      userId: str,
+      chapterId: str,
+      pageId: str,
+      dateUpdated: strN,
+      chapterSummary: { ...ref("ChapterSummary"), nullable: true } as Schema,
+      pageSummary: { ...ref("PageSummary"), nullable: true } as Schema,
+    },
+    ["userId", "chapterId", "pageId"],
+  ),
+  EntitlementOut: obj(
+    { userId: str, chapterId: str, grantType: enumStr("chapter_unlock"), source: strN, txRef: strN, id: strN, createdAt: dateStrN },
+    ["userId", "chapterId"],
+  ),
+
+  // -- payments --------------------------------------------------------------
+  CheckoutSessionOut: obj(
+    {
+      checkoutUrl: str,
+      provider: enumStr("flutterwave", "paystack", "stripe"),
+      providerReference: str,
+      txRef: str,
+      status: enumStr("initiated", "pending", "verified", "fulfilled", "failed"),
+      expiresAt: strN,
+    },
+    ["checkoutUrl", "provider", "providerReference", "txRef", "status"],
+  ),
+  PaymentBundlesOut: obj(
+    {
+      id: str,
+      amount: intN,
+      numberOfstars: intN,
+      bundleType: enumStrN(
+        "cash",
+        "purchaseOfBooks",
+        "transferringStarsToOtherUsers",
+        "cashPromo",
+        "bookPromo",
+        "subscription",
+        "subscriptionCash",
+        "subscriptionStars",
+      ),
+      durationDays: intN,
+      description: str,
+      dateCreated: dateStrN,
+    },
+    ["id", "description"],
+  ),
+  PricingBundleOut: obj(
+    { id: str, bundleType: str, description: str, durationDays: intN, cashAmount: intN, starAmount: intN, dateCreated: dateStrN },
+    ["id", "bundleType", "description"],
+  ),
+  PricingCatalogOut: obj(
+    {
+      subscriptionPlans: arr(ref("PricingBundleOut")),
+      starBundles: arr(ref("PricingBundleOut")),
+      chapterUnlockBundles: arr(ref("PricingBundleOut")),
+    },
+    ["subscriptionPlans", "starBundles", "chapterUnlockBundles"],
+  ),
+
+  // -- admin -----------------------------------------------------------------
+  NewAdminOut: obj(
+    {
+      email: str,
+      invitedBy: strN,
+      userId: strN,
+      accessToken: strN,
+      refreshToken: strN,
+      firstName: strN,
+      lastName: strN,
+      avatar: strN,
+      dateCreated: dateStrN,
+    },
+    ["email"],
+  ),
+  ChapterInteractionUserOut: obj(
+    { userId: str, firstName: strN, lastName: strN, email: strN, avatar: strN, interactionCount: int, lastInteractionAt: strN },
+    ["userId"],
+  ),
+  AnalyticsMetric: obj({ total: strN, change: strN, changeType: enumStrN("increase", "decrease", "no change") }),
+  AdminDashboardAnalytics: obj({
+    chapterAnalytics: ref("AnalyticsMetric"),
+    pageAnalytics: ref("AnalyticsMetric"),
+    readerAnalytics: ref("AnalyticsMetric"),
+    revenueAnalytics: ref("AnalyticsMetric"),
+    recentChapters: arr(ref("ChapterOut")),
+    recentUsers: arr(ref("UserOut")),
+  }),
+
+  // -- request bodies --------------------------------------------------------
+  NewUserBase: obj(
+    {
+      provider: enumStr("credentials", "google"),
+      email: { type: "string", format: "email" },
+      password: strN,
+      googleAccessToken: strN,
+      firstName: strN,
+      lastName: strN,
+      avatar: strN,
+    },
+    ["provider", "email"],
+  ),
+  OldUserBase: obj(
+    { email: { type: "string", format: "email" }, password: str, provider: enumStr("credentials", "google") },
+    ["email", "password"],
+  ),
+  RefreshTokenRequest: obj({ refreshToken: str }, ["refreshToken"]),
+  UserUpdate: obj({ firstName: strN, lastName: strN, avatar: strN, status: enumStrN("Active", "Inactive", "Suspended") }),
+  EmailBody: obj({ email: { type: "string", format: "email" } }, ["email"]),
+  ConcludePasswordBody: obj({ email: { type: "string", format: "email" }, otp: str, password: str }, ["email", "otp", "password"]),
+  GoogleExchangeRequest: obj({ code: str }, ["code"]),
+  NewAdminCreate: obj(
+    { email: { type: "string", format: "email" }, password: str, firstName: strN, lastName: strN, avatar: strN },
+    ["email", "password"],
+  ),
+  AdminBase: obj({ email: { type: "string", format: "email" }, password: str }, ["email", "password"]),
+  AdminUpdate: obj({ firstName: strN, lastName: strN, avatar: strN }),
+  VerificationRequest: obj({ access_token: str, otp: str }, ["access_token", "otp"]),
+  InviteBody: obj({ email: { type: "string", format: "email" } }, ["email"]),
+  BookBaseRequest: obj({ name: str }, ["name"]),
+  BookUpdate: obj({ name: strN, number: intN, chapterCount: intN, chapters: strArrN }),
+  ChapterBaseRequest: obj(
+    { bookId: str, chapterLabel: str, status: strN, accessType, unlockBundleId: strN, coverImage: strN },
+    ["bookId", "chapterLabel"],
+  ),
+  ChapterUpdateRequest: obj({ chapterLabel: strN, status: strN, accessType, unlockBundleId: strN, coverImage: strN }),
+  PageBase: obj({ chapterId: str, textContent: str, status: str }, ["chapterId", "textContent", "status"]),
+  PageUpdateRequest: obj({ textContent: str, status: strN }, ["textContent"]),
+  BookMarkCreateRequest: obj({ targetType, targetId: strN, pageId: strN }),
+  LikeBaseRequest: obj({ chapterId: str }, ["chapterId"]),
+  CommentCreateRequest: obj(
+    {
+      text: str,
+      targetType,
+      targetId: strN,
+      chapterId: strN,
+      parentCommentId: strN,
+      commentType: enumStrN("reply_target", "Reply To Chapter", "Reply To Comment", "Reply To Reply"),
+    },
+    ["text"],
+  ),
+  UpdateCommentBaseRequest: obj({ commentId: str, text: str }, ["commentId", "text"]),
+  AuthorRoomBase: obj({ text: str, chapterId: str }, ["text", "chapterId"]),
+  AuthorRoomUpdate: obj({ text: str }, ["text"]),
+  ReactionBase: obj({ reaction: str, authorRoomId: str, userId: str }, ["reaction", "authorRoomId", "userId"]),
+  ReactionUpdate: obj({ reaction: strN }),
+  CheckoutCreateRequest: obj(
+    {
+      bundleId: str,
+      countryCode: { type: "string", minLength: 2, maxLength: 2 },
+      provider: enumStrN("flutterwave", "paystack", "stripe"),
+      chapterId: strN,
+      successUrl: strN,
+      cancelUrl: strN,
+    },
+    ["bundleId", "countryCode"],
+  ),
+  SubscriptionStarsPurchaseRequest: obj({ bundleId: str }, ["bundleId"]),
+  ChapterPayment: obj({ bundleId: str }, ["bundleId"]),
+  PaymentLink: obj({ bundleId: str, chapterId: strN }, ["bundleId"]),
+  PaymentBundles: obj(
+    {
+      bundleType: enumStr(
+        "cash",
+        "purchaseOfBooks",
+        "transferringStarsToOtherUsers",
+        "cashPromo",
+        "bookPromo",
+        "subscription",
+        "subscriptionCash",
+        "subscriptionStars",
+      ),
+      amount: intN,
+      numberOfstars: intN,
+      durationDays: intN,
+      description: str,
+    },
+    ["bundleType", "description"],
+  ),
+  PaymentBundlesUpdate: obj({ amount: intN, numberOfstars: intN, durationDays: intN, description: strN }),
+};

--- a/mei-next/lib/openapi/spec.ts
+++ b/mei-next/lib/openapi/spec.ts
@@ -1,0 +1,238 @@
+/**
+ * Builds the OpenAPI 3.0 document for the v2 API from the route inventory
+ * (see ../../../nextjs-migration/endpoints.md). Served at /openapi.json and
+ * rendered by the Scalar UI at /docs.
+ */
+import { schemas, securitySchemes } from "./schemas";
+
+type Schema = Record<string, unknown>;
+type Sec = "member" | "admin" | "any" | "none";
+
+const ref = (n: string): Schema => ({ $ref: `#/components/schemas/${n}` });
+const obj = (properties: Record<string, Schema>, required?: string[]): Schema => ({
+  type: "object",
+  properties,
+  ...(required && required.length ? { required } : {}),
+});
+const arr = (items: Schema): Schema => ({ type: "array", items });
+const json = (schema: Schema) => ({ "application/json": { schema } });
+
+/** Success envelope wrapping a data schema. */
+const env = (data: Schema): Schema =>
+  obj({ success: { type: "boolean", enum: [true] }, message: { type: "string" }, data }, ["success", "message", "data"]);
+/** Enveloped PaginatedListOut (flat items + meta + summary). */
+const envPaged = (item: Schema): Schema =>
+  env(obj({ items: arr(item), meta: ref("ListMeta"), summary: ref("ListSummary") }, ["items", "meta", "summary"]));
+/** Enveloped indexed list ({index,item} + meta) — user-v2 likes/bookmarks only. */
+const envIndexed = (item: Schema): Schema =>
+  env(obj({ items: arr(obj({ index: { type: "integer" }, item }, ["index", "item"])), meta: ref("ListMeta") }, ["items", "meta"]));
+
+const errorRef = json(ref("ErrorEnvelope"));
+
+interface OpOpts {
+  summary: string;
+  tag: string;
+  sec: Sec;
+  desc?: string;
+  path?: string[]; // path param names
+  query?: string[]; // query param names (skip|limit|targetType|targetId|redirect_path|target)
+  body?: string; // request-body schema name
+  ok: Schema; // success response body schema
+  okStatus?: number;
+  redirect?: boolean; // 302 endpoints
+}
+
+function qParam(name: string): Schema {
+  const base: Record<string, Schema> = {
+    skip: { name: "skip", in: "query", schema: { type: "integer", default: 0, minimum: 0 } },
+    limit: { name: "limit", in: "query", schema: { type: "integer", default: 20, minimum: 1, maximum: 100 } },
+    targetType: { name: "targetType", in: "query", schema: { type: "string", enum: ["book", "chapter", "page"] } },
+    targetId: { name: "targetId", in: "query", schema: { type: "string" } },
+    target: { name: "target", in: "query", schema: { type: "string" }, description: "OAuth target alias" },
+    redirect_path: { name: "redirect_path", in: "query", schema: { type: "string", maxLength: 512 } },
+  };
+  return base[name] ?? { name, in: "query", schema: { type: "string" } };
+}
+
+function operation(o: OpOpts): Schema {
+  const op: Schema = { tags: [o.tag], summary: o.summary };
+  if (o.desc) op.description = o.desc;
+  if (o.sec !== "none") {
+    op.security = [{ bearerAuth: [] }];
+    const note = o.sec === "admin" ? "Admin token required." : o.sec === "any" ? "Member or admin token." : "Member token required.";
+    op.description = (o.desc ? o.desc + " " : "") + note;
+  }
+  const parameters: Schema[] = [];
+  for (const p of o.path ?? []) parameters.push({ name: p, in: "path", required: true, schema: { type: "string" } });
+  for (const q of o.query ?? []) parameters.push(qParam(q));
+  if (parameters.length) op.parameters = parameters;
+  if (o.body) op.requestBody = { required: true, content: json(ref(o.body)) };
+
+  const okStatus = String(o.okStatus ?? 200);
+  const responses: Record<string, Schema> = o.redirect
+    ? { "302": { description: "Redirect to Google / the frontend target" } }
+    : { [okStatus]: { description: "Success", content: json(o.ok) } };
+  if (!o.redirect) {
+    responses["400"] = { description: "Bad request", content: errorRef };
+    responses["404"] = { description: "Not found", content: errorRef };
+    responses["422"] = { description: "Validation error", content: errorRef };
+    if (o.sec !== "none") {
+      responses["401"] = { description: "Invalid/expired token", content: errorRef };
+      responses["403"] = { description: "Missing Authorization header / forbidden", content: errorRef };
+    }
+  }
+  op.responses = responses;
+  return op;
+}
+
+type Route = [method: string, path: string, opts: OpOpts];
+
+const ROUTES: Route[] = [
+  // ---- System --------------------------------------------------------------
+  ["get", "/health", { summary: "Liveness check (not enveloped)", tag: "System", sec: "none", ok: ref("HealthOut") }],
+
+  // ---- User ----------------------------------------------------------------
+  ["get", "/api/v2/user/details", { summary: "Aggregated user details", tag: "User", sec: "member", ok: env(ref("UserDetailsV2Out")) }],
+  ["get", "/api/v2/user/likes", { summary: "My likes (indexed, paginated)", tag: "User", sec: "member", query: ["skip", "limit"], ok: envIndexed(ref("LikeOut")) }],
+  ["get", "/api/v2/user/bookmarks", { summary: "My bookmarks (indexed, paginated)", tag: "User", sec: "member", query: ["skip", "limit"], ok: envIndexed(ref("BookMarkOut")) }],
+  ["get", "/api/v2/user/reading/progress", { summary: "My reading progress", tag: "User", sec: "member", ok: env(ref("ReadingProgressOut")) }],
+  ["post", "/api/v2/user/sign-up", { summary: "Register (credentials)", tag: "User", sec: "none", body: "NewUserBase", ok: env(ref("NewUserOut")) }],
+  ["post", "/api/v2/user/sign-in", { summary: "Login (credentials)", tag: "User", sec: "none", body: "OldUserBase", ok: env(ref("OldUserOut")) }],
+  ["post", "/api/v2/user/refresh", { summary: "Refresh access+refresh tokens", tag: "User", sec: "none", desc: "Send the (expired) access JWT in Authorization plus the refresh token in the body.", body: "RefreshTokenRequest", ok: env(ref("TokenRefreshOut")) }],
+  ["get", "/api/v2/user/google/auth", { summary: "Start Google OAuth", tag: "User", sec: "none", query: ["target", "redirect_path"], ok: ref("MessageOut"), redirect: true }],
+  ["get", "/api/v2/user/google/callback", { summary: "Google OAuth callback", tag: "User", sec: "none", ok: ref("MessageOut"), redirect: true }],
+  ["get", "/api/v2/user/auth/callback", { summary: "Google OAuth callback (alias)", tag: "User", sec: "none", ok: ref("MessageOut"), redirect: true }],
+  ["post", "/api/v2/user/google/exchange", { summary: "Exchange one-time OAuth code for tokens", tag: "User", sec: "none", body: "GoogleExchangeRequest", ok: env(ref("OldUserOut")) }],
+  ["post", "/api/v2/user/initiate/change-password", { summary: "Send password-reset OTP", tag: "User", sec: "none", body: "EmailBody", ok: env(ref("MessageOut")) }],
+  ["post", "/api/v2/user/conclude/change-password", { summary: "Complete password reset", tag: "User", sec: "none", body: "ConcludePasswordBody", ok: env(ref("MessageOut")) }],
+  ["patch", "/api/v2/user/update", { summary: "Update my profile", tag: "User", sec: "member", body: "UserUpdate", ok: env(ref("NewUserOut")) }],
+  ["get", "/api/v2/user/all/user-details", { summary: "List all users", tag: "User", sec: "admin", ok: env(arr(ref("UserOut"))) }],
+  ["get", "/api/v2/user/{userId}/user-details", { summary: "User details with chapter read-flags", tag: "User", sec: "admin", path: ["userId"], ok: env(ref("UserOutChapterDetails")) }],
+  ["patch", "/api/v2/user/{userId}/status/{new_status}", { summary: "Change user status", tag: "User", sec: "admin", path: ["userId", "new_status"], ok: env(ref("MessageOut")) }],
+
+  // ---- Admin ---------------------------------------------------------------
+  ["post", "/api/v2/admin/invite", { summary: "Invite an admin", tag: "Admin", sec: "admin", body: "InviteBody", ok: env(ref("MessageOut")) }],
+  ["post", "/api/v2/admin/sign-up", { summary: "Admin register (invite-gated)", tag: "Admin", sec: "none", body: "NewAdminCreate", ok: env(ref("NewAdminOut")) }],
+  ["post", "/api/v2/admin/sign-in", { summary: "Admin login (issues inactive token + OTP email)", tag: "Admin", sec: "none", body: "AdminBase", ok: env(ref("NewAdminOut")) }],
+  ["post", "/api/v2/admin/verify", { summary: "Verify admin OTP (activates token)", tag: "Admin", sec: "none", body: "VerificationRequest", ok: env(ref("MessageOut")) }],
+  ["post", "/api/v2/admin/refresh", { summary: "Refresh admin tokens", tag: "Admin", sec: "none", body: "RefreshTokenRequest", ok: env(ref("TokenRefreshOut")) }],
+  ["post", "/api/v2/admin/initiate/change-password", { summary: "Send admin password-reset OTP", tag: "Admin", sec: "none", body: "EmailBody", ok: env(ref("MessageOut")) }],
+  ["post", "/api/v2/admin/conclude/change-password", { summary: "Complete admin password reset", tag: "Admin", sec: "none", body: "ConcludePasswordBody", ok: env(ref("MessageOut")) }],
+  ["get", "/api/v2/admin/details", { summary: "My admin details", tag: "Admin", sec: "admin", ok: env(ref("NewAdminOut")) }],
+  ["get", "/api/v2/admin/all/details", { summary: "List all admins", tag: "Admin", sec: "admin", ok: env(arr(ref("NewAdminOut"))) }],
+  ["patch", "/api/v2/admin/update", { summary: "Update admin profile", tag: "Admin", sec: "admin", body: "AdminUpdate", ok: env(ref("NewAdminOut")) }],
+  ["get", "/api/v2/admin/dashboardAnalytics", { summary: "Dashboard analytics", tag: "Admin", sec: "admin", ok: env(ref("AdminDashboardAnalytics")) }],
+
+  // ---- Book (all admin) ----------------------------------------------------
+  ["get", "/api/v2/book/get", { summary: "List books", tag: "Book", sec: "admin", query: ["skip", "limit"], ok: envPaged(ref("BookOut")) }],
+  ["post", "/api/v2/book/create", { summary: "Create book", tag: "Book", sec: "admin", body: "BookBaseRequest", ok: env(ref("BookOut")) }],
+  ["delete", "/api/v2/book/delete/{bookId}", { summary: "Delete book (cascades)", tag: "Book", sec: "admin", path: ["bookId"], ok: env(ref("BookOut")) }],
+  ["patch", "/api/v2/book/update/{bookId}", { summary: "Update book", tag: "Book", sec: "admin", path: ["bookId"], body: "BookUpdate", ok: env(ref("BookOut")) }],
+
+  // ---- Chapter -------------------------------------------------------------
+  ["get", "/api/v2/chapter/admin/get/allChapters/{bookId}", { summary: "List chapters (admin)", tag: "Chapter", sec: "admin", path: ["bookId"], query: ["skip", "limit"], ok: envPaged(ref("ChapterOut")) }],
+  ["get", "/api/v2/chapter/user/get/allChapters/{bookId}", { summary: "List chapters (reader)", tag: "Chapter", sec: "any", path: ["bookId"], query: ["skip", "limit"], ok: envPaged(ref("ChapterOut")) }],
+  ["get", "/api/v2/chapter/admin/get/chapterId/{chapterId}", { summary: "Get chapter by id (admin)", tag: "Chapter", sec: "admin", path: ["chapterId"], ok: env(ref("ChapterOut")) }],
+  ["get", "/api/v2/chapter/admin/get/{bookId}/{chapterNumber}", { summary: "Get chapter by number (public)", tag: "Chapter", sec: "none", path: ["bookId", "chapterNumber"], ok: env(ref("ChapterOut")) }],
+  ["get", "/api/v2/chapter/user/get/chapterId/{chapterId}", { summary: "Get chapter by id (reader)", tag: "Chapter", sec: "any", path: ["chapterId"], ok: env(ref("ChapterOut")) }],
+  ["get", "/api/v2/chapter/user/get/{bookId}/{chapterNumber}", { summary: "Get chapter by number (reader)", tag: "Chapter", sec: "any", path: ["bookId", "chapterNumber"], ok: env(ref("ChapterOut")) }],
+  ["post", "/api/v2/chapter/create", { summary: "Create chapter", tag: "Chapter", sec: "admin", body: "ChapterBaseRequest", ok: env(ref("ChapterOut")) }],
+  ["delete", "/api/v2/chapter/delete/{chapterId}", { summary: "Delete chapter (cascades pages)", tag: "Chapter", sec: "admin", path: ["chapterId"], ok: env(ref("ChapterOut")) }],
+  ["patch", "/api/v2/chapter/update/{chapterId}", { summary: "Update chapter", tag: "Chapter", sec: "admin", path: ["chapterId"], body: "ChapterUpdateRequest", ok: env(ref("ChapterOut")) }],
+
+  // ---- Page ----------------------------------------------------------------
+  ["get", "/api/v2/page/get/{chapterId}", { summary: "List pages of a chapter", tag: "Page", sec: "any", path: ["chapterId"], query: ["skip", "limit"], ok: envPaged(ref("PageOut")) }],
+  ["get", "/api/v2/page/get/page/{pageId}", { summary: "Get a page (tracks reading progress for members)", tag: "Page", sec: "any", path: ["pageId"], ok: env(ref("PageOut")) }],
+  ["post", "/api/v2/page/create/{bookId}", { summary: "Create page", tag: "Page", sec: "admin", path: ["bookId"], body: "PageBase", ok: env(ref("PageOut")) }],
+  ["delete", "/api/v2/page/delete/{pageId}", { summary: "Delete page", tag: "Page", sec: "admin", path: ["pageId"], ok: env(ref("MessageOut")) }],
+  ["patch", "/api/v2/page/update/{pageId}", { summary: "Update page", tag: "Page", sec: "admin", path: ["pageId"], body: "PageUpdateRequest", ok: env(ref("PageOut")) }],
+
+  // ---- Bookmark ------------------------------------------------------------
+  ["get", "/api/v2/bookmark/get", { summary: "My bookmarks", tag: "Bookmark", sec: "any", query: ["targetType", "skip", "limit"], ok: envPaged(ref("BookMarkOut")) }],
+  ["get", "/api/v2/bookmark/get/{userId}", { summary: "Bookmarks for a user (self only)", tag: "Bookmark", sec: "any", path: ["userId"], query: ["targetType", "skip", "limit"], ok: envPaged(ref("BookMarkOut")) }],
+  ["post", "/api/v2/bookmark/create", { summary: "Create bookmark", tag: "Bookmark", sec: "any", body: "BookMarkCreateRequest", ok: env(ref("BookMarkOut")) }],
+  ["delete", "/api/v2/bookmark/remove/{bookmarkId}", { summary: "Remove bookmark", tag: "Bookmark", sec: "any", path: ["bookmarkId"], ok: env(ref("BookMarkOut")) }],
+
+  // ---- Like ----------------------------------------------------------------
+  ["get", "/api/v2/like/get", { summary: "My likes", tag: "Like", sec: "any", query: ["skip", "limit"], ok: envPaged(ref("LikeOut")) }],
+  ["get", "/api/v2/like/get/{chapterId}", { summary: "Likes on a chapter (with users)", tag: "Like", sec: "none", path: ["chapterId"], query: ["skip", "limit"], ok: envPaged(ref("LikeWithUserOut")) }],
+  ["get", "/api/v2/like/admin/get/chapter/{chapterId}/users", { summary: "Users who liked a chapter", tag: "Like", sec: "admin", path: ["chapterId"], query: ["skip", "limit"], ok: envPaged(ref("ChapterInteractionUserOut")) }],
+  ["post", "/api/v2/like/create", { summary: "Like a chapter", tag: "Like", sec: "any", body: "LikeBaseRequest", ok: env(ref("LikeOut")) }],
+  ["delete", "/api/v2/like/remove/{likeId}", { summary: "Remove a like", tag: "Like", sec: "none", path: ["likeId"], ok: env(ref("LikeOut")) }],
+
+  // ---- Comment -------------------------------------------------------------
+  ["get", "/api/v2/comment/get", { summary: "Comments by target (or mine)", tag: "Comment", sec: "any", query: ["targetType", "targetId", "skip", "limit"], ok: envPaged(ref("CommentOut")) }],
+  ["get", "/api/v2/comment/get/target/{targetType}/{targetId}", { summary: "Comments by target", tag: "Comment", sec: "none", path: ["targetType", "targetId"], query: ["skip", "limit"], ok: envPaged(ref("CommentOut")) }],
+  ["get", "/api/v2/comment/get/{chapterId}", { summary: "Comments on a chapter (legacy)", tag: "Comment", sec: "none", path: ["chapterId"], query: ["skip", "limit"], ok: envPaged(ref("CommentOut")) }],
+  ["get", "/api/v2/comment/admin/get/chapter/{chapterId}/users", { summary: "Users who commented on a chapter", tag: "Comment", sec: "admin", path: ["chapterId"], query: ["skip", "limit"], ok: envPaged(ref("ChapterInteractionUserOut")) }],
+  ["post", "/api/v2/comment/create", { summary: "Create comment", tag: "Comment", sec: "any", body: "CommentCreateRequest", ok: env(ref("CommentOut")) }],
+  ["delete", "/api/v2/comment/user/remove/{commentId}", { summary: "Remove my comment", tag: "Comment", sec: "any", path: ["commentId"], ok: env(ref("CommentOut")) }],
+  ["delete", "/api/v2/comment/admin/remove/{commentId}", { summary: "Remove any comment (admin)", tag: "Comment", sec: "admin", path: ["commentId"], ok: env(ref("CommentOut")) }],
+  ["patch", "/api/v2/comment/update", { summary: "Edit a comment", tag: "Comment", sec: "any", body: "UpdateCommentBaseRequest", ok: env(ref("CommentOut")) }],
+
+  // ---- Author rooms --------------------------------------------------------
+  ["get", "/api/v2/author_room/", { summary: "List author rooms", tag: "AuthorRoom", sec: "member", query: ["skip", "limit"], ok: envPaged(ref("AuthorRoomOut")) }],
+  ["post", "/api/v2/author_room/", { summary: "Create author room", tag: "AuthorRoom", sec: "any", body: "AuthorRoomBase", ok: env(ref("AuthorRoomOut")), okStatus: 201 }],
+  ["get", "/api/v2/author_room/{id}", { summary: "Get author room", tag: "AuthorRoom", sec: "member", path: ["id"], ok: env(ref("AuthorRoomOut")) }],
+  ["patch", "/api/v2/author_room/{id}", { summary: "Update author room", tag: "AuthorRoom", sec: "any", path: ["id"], body: "AuthorRoomUpdate", ok: env(ref("AuthorRoomOut")) }],
+  ["delete", "/api/v2/author_room/{id}", { summary: "Delete author room (admin)", tag: "AuthorRoom", sec: "admin", path: ["id"], ok: env(ref("DeletedOut")) }],
+
+  // ---- Reactions -----------------------------------------------------------
+  ["get", "/api/v2/reactions/", { summary: "List reactions", tag: "Reactions", sec: "none", query: ["skip", "limit"], ok: envPaged(ref("ReactionOut")) }],
+  ["post", "/api/v2/reactions/", { summary: "Create reaction", tag: "Reactions", sec: "member", body: "ReactionBase", ok: env(ref("ReactionOut")), okStatus: 201 }],
+  ["get", "/api/v2/reactions/{authorRoomId}", { summary: "My reaction for a room", tag: "Reactions", sec: "member", path: ["authorRoomId"], ok: env(ref("ReactionOut")) }],
+  ["patch", "/api/v2/reactions/{authorRoomId}", { summary: "Update my reaction", tag: "Reactions", sec: "member", path: ["authorRoomId"], body: "ReactionUpdate", ok: env(ref("ReactionOut")) }],
+  ["delete", "/api/v2/reactions/{authorRoomId}", { summary: "Delete my reaction", tag: "Reactions", sec: "member", path: ["authorRoomId"], ok: env({ type: "object", nullable: true }) }],
+
+  // ---- Payments ------------------------------------------------------------
+  ["get", "/api/v2/payment/get-payment-bundles", { summary: "List payment bundles", tag: "Payment", sec: "any", query: ["skip", "limit"], ok: envPaged(ref("PaymentBundlesOut")) }],
+  ["get", "/api/v2/payment/pricing", { summary: "Pricing catalog", tag: "Payment", sec: "any", ok: env(ref("PricingCatalogOut")) }],
+  ["post", "/api/v2/payment/create-payment-bundle", { summary: "Create a bundle", tag: "Payment", sec: "admin", body: "PaymentBundles", ok: env(ref("PaymentBundlesOut")) }],
+  ["patch", "/api/v2/payment/update-payment-bundle/{bundleId}", { summary: "Update a bundle", tag: "Payment", sec: "admin", path: ["bundleId"], body: "PaymentBundlesUpdate", ok: env(ref("MessageOut")) }],
+  ["delete", "/api/v2/payment/delete-payment-bundle/{bundleId}", { summary: "Delete a bundle", tag: "Payment", sec: "admin", path: ["bundleId"], ok: env(ref("MessageOut")) }],
+  ["post", "/api/v2/payment/checkout/create", { summary: "Create a cash checkout session", tag: "Payment", sec: "member", body: "CheckoutCreateRequest", ok: env(ref("CheckoutSessionOut")) }],
+  ["post", "/api/v2/payment/create-payment-link", { summary: "Create payment link (legacy, NG/flutterwave)", tag: "Payment", sec: "member", body: "PaymentLink", ok: env(ref("CheckoutSessionOut")) }],
+  ["post", "/api/v2/payment/pay-chapter", { summary: "Unlock a chapter with stars", tag: "Payment", sec: "member", body: "ChapterPayment", ok: env(ref("MessageOut")) }],
+  ["post", "/api/v2/payment/subscribe-with-stars", { summary: "Subscribe using stars", tag: "Payment", sec: "member", body: "SubscriptionStarsPurchaseRequest", ok: env(ref("MessageOut")) }],
+  ["post", "/api/v2/payment/webhooks/flutterwave", { summary: "Flutterwave webhook (raw body, verif-hash)", tag: "Payment", sec: "none", ok: env(ref("WebhookResultOut")) }],
+  ["post", "/api/v2/payment/webhooks/paystack", { summary: "Paystack webhook (raw body, HMAC-SHA512)", tag: "Payment", sec: "none", ok: env(ref("WebhookResultOut")) }],
+  ["post", "/api/v2/payment/webhooks/stripe", { summary: "Stripe webhook (raw body, signature)", tag: "Payment", sec: "none", ok: env(ref("WebhookResultOut")) }],
+  ["post", "/api/v2/payment/webhook", { summary: "Legacy Flutterwave webhook alias", tag: "Payment", sec: "none", ok: env(ref("WebhookResultOut")) }],
+];
+
+const TAGS = [
+  { name: "System", description: "Liveness." },
+  { name: "User", description: "Auth, profile, Google OAuth, and member-facing reads." },
+  { name: "Admin", description: "Admin auth (OTP-gated), management, and analytics." },
+  { name: "Book", description: "Books (admin only)." },
+  { name: "Chapter", description: "Chapters; access-gated for readers." },
+  { name: "Page", description: "Pages; reading single pages tracks progress." },
+  { name: "Bookmark", description: "Polymorphic bookmarks." },
+  { name: "Like", description: "Chapter likes." },
+  { name: "Comment", description: "Polymorphic, threaded comments." },
+  { name: "AuthorRoom", description: "Author/chapter discussion rooms." },
+  { name: "Reactions", description: "Reactions on author rooms." },
+  { name: "Payment", description: "Bundles, checkout, stars wallet, and webhooks." },
+];
+
+export function buildOpenApiSpec(origin: string): Record<string, unknown> {
+  const paths: Record<string, Record<string, Schema>> = {};
+  for (const [method, path, opts] of ROUTES) {
+    (paths[path] ??= {})[method] = operation(opts);
+  }
+  return {
+    openapi: "3.0.3",
+    info: {
+      title: "MIE / Echoes Novel-App API (v2)",
+      version: "2.0.0",
+      description:
+        "Next.js port of the v2 API. Every 2xx JSON response is wrapped in a success envelope " +
+        "`{ success, message, data }`; errors use `{ success:false, message, data:null, errors? }`. " +
+        "List endpoints return `{ items, meta, summary }`. Auth is a stateful Bearer JWT.",
+    },
+    servers: [{ url: origin || "/" }],
+    tags: TAGS,
+    paths,
+    components: { securitySchemes, schemas },
+  };
+}


### PR DESCRIPTION
Restores the interactive API docs the FastAPI backend had at /docs.

- GET /openapi.json: full OpenAPI 3.0 document covering all 80 v2 endpoints, with component schemas for the success/error envelope, pagination, and every response/request body (including the wire quirks). servers[] is derived from the request origin so "Try it out" targets the current deployment.
- GET /docs: Scalar API Reference UI loading the spec. The Scalar bundle is pinned to a specific jsDelivr version with Subresource Integrity (sha384) + crossorigin, so a CDN compromise cannot substitute the script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive API documentation accessible at `/docs` endpoint using Scalar API Reference UI
  * Exposed OpenAPI 3.0 specification at `/openapi.json` endpoint with complete API schema definitions, security configurations, and endpoint documentation
  * Implemented comprehensive API contract documentation covering authentication, request/response models, and all available endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->