### PR TITLE
feat(payments): add optional features string[] to payment bundles

### DIFF
--- a/mei-next/app/api/v2/payment/create-payment-bundle/route.ts
+++ b/mei-next/app/api/v2/payment/create-payment-bundle/route.ts
@@ -30,6 +30,7 @@ const PaymentBundles = z.object({
   numberOfstars: z.number().int().nullish(),
   durationDays: z.number().int().nullish(),
   description: z.string(),
+  features: z.array(z.string()).nullish(),
 });
 
 /**

--- a/mei-next/app/api/v2/payment/update-payment-bundle/[bundleId]/route.ts
+++ b/mei-next/app/api/v2/payment/update-payment-bundle/[bundleId]/route.ts
@@ -29,6 +29,7 @@ const PaymentBundlesUpdate = z.object({
   numberOfstars: z.number().int().nullish(),
   durationDays: z.number().int().nullish(),
   description: z.string().nullish(),
+  features: z.array(z.string()).nullish(),
 });
 
 /**

--- a/mei-next/lib/models/paymentBundle.ts
+++ b/mei-next/lib/models/paymentBundle.ts
@@ -23,6 +23,10 @@ const PaymentBundleSchema = new Schema<PaymentBundleDoc>(
     numberOfstars: { type: Number, default: null },
     durationDays: { type: Number, default: null }, // subscriptions
     description: { type: String, required: true },
+    // Frontend-rendered feature bullets. Optional; absent on legacy docs (the
+    // serializer defaults those to `[]`). `default: undefined` keeps the key off
+    // documents that never set it rather than storing an empty array.
+    features: { type: [String], default: undefined },
     dateCreated: { type: Number }, // epoch seconds
     dateUpdated: { type: Number }, // epoch seconds
   },

--- a/mei-next/lib/openapi/schemas.ts
+++ b/mei-next/lib/openapi/schemas.ts
@@ -331,13 +331,14 @@ export const schemas: Record<string, Schema> = {
       ),
       durationDays: intN,
       description: str,
+      features: arr(str),
       dateCreated: dateStrN,
     },
-    ["id", "description"],
+    ["id", "description", "features"],
   ),
   PricingBundleOut: obj(
-    { id: str, bundleType: str, description: str, durationDays: intN, cashAmount: intN, starAmount: intN, dateCreated: dateStrN },
-    ["id", "bundleType", "description"],
+    { id: str, bundleType: str, description: str, features: arr(str), durationDays: intN, cashAmount: intN, starAmount: intN, dateCreated: dateStrN },
+    ["id", "bundleType", "description", "features"],
   ),
   PricingCatalogOut: obj(
     {
@@ -464,8 +465,9 @@ export const schemas: Record<string, Schema> = {
       numberOfstars: intN,
       durationDays: intN,
       description: str,
+      features: arr(str),
     },
     ["bundleType", "description"],
   ),
-  PaymentBundlesUpdate: obj({ amount: intN, numberOfstars: intN, durationDays: intN, description: strN }),
+  PaymentBundlesUpdate: obj({ amount: intN, numberOfstars: intN, durationDays: intN, description: strN, features: arr(str) }),
 };

--- a/mei-next/lib/payments/bundles.ts
+++ b/mei-next/lib/payments/bundles.ts
@@ -62,6 +62,7 @@ export interface PaymentBundleCreateInput {
   numberOfstars?: number | null;
   durationDays?: number | null;
   description: string;
+  features?: string[] | null;
 }
 
 export interface PaymentBundleUpdateInput {
@@ -70,6 +71,7 @@ export interface PaymentBundleUpdateInput {
   numberOfstars?: number | null;
   durationDays?: number | null;
   description?: string | null;
+  features?: string[] | null;
 }
 
 /** Pydantic-style 422 (after-validator ValueError → "Value error, <msg>"). */
@@ -163,6 +165,9 @@ export async function createBundle(input: PaymentBundleCreateInput): Promise<Pay
   if (normalized.durationDays !== null && normalized.durationDays !== undefined) {
     fields.durationDays = normalized.durationDays;
   }
+  if (normalized.features !== null && normalized.features !== undefined) {
+    fields.features = normalized.features;
+  }
   fields.dateCreated = nowEpoch();
 
   const created = await PaymentBundle.create(fields);
@@ -195,6 +200,9 @@ export async function updateBundle(bundleId: string, input: PaymentBundleUpdateI
   }
   if (normalized.description !== null && normalized.description !== undefined) {
     partial.description = normalized.description;
+  }
+  if (normalized.features !== null && normalized.features !== undefined) {
+    partial.features = normalized.features;
   }
   if (Object.keys(partial).length === 0) return false;
   partial.dateUpdated = nowEpoch();

--- a/mei-next/lib/serializers/payment.ts
+++ b/mei-next/lib/serializers/payment.ts
@@ -5,7 +5,7 @@
  * - Bundle `dateCreated` is stored as epoch seconds → ISO `+00:00`.
  */
 import { nowIso, toIsoOffset } from "@/lib/util/dates";
-import { type AnyDoc, docId, numOrDefault, numOrNull, strOrNull } from "./common";
+import { type AnyDoc, docId, numOrDefault, numOrNull, strArrOrNull, strOrNull } from "./common";
 
 export type TransactionType =
   | "cash"
@@ -43,6 +43,8 @@ export interface PaymentBundlesOut {
   bundleType: BundleType | null;
   durationDays: number | null;
   description: string;
+  /** Feature bullets for list rendering; `[]` when the doc has none. */
+  features: string[];
   dateCreated: string | null;
 }
 
@@ -50,6 +52,8 @@ export interface PricingBundleOut {
   id: string;
   bundleType: BundleType;
   description: string;
+  /** Feature bullets for list rendering; `[]` when the doc has none. */
+  features: string[];
   durationDays: number | null;
   cashAmount: number | null;
   starAmount: number | null;
@@ -89,6 +93,7 @@ export function toPaymentBundlesOut(doc: AnyDoc): PaymentBundlesOut {
     bundleType: normalizeBundleType(doc.bundleType),
     durationDays: numOrNull(doc.durationDays),
     description: String(doc.description ?? ""),
+    features: strArrOrNull(doc.features) ?? [],
     dateCreated: toIsoOffset(doc.dateCreated),
   };
 }
@@ -98,6 +103,7 @@ export function toPricingBundleOut(doc: AnyDoc): PricingBundleOut {
     id: docId(doc),
     bundleType: normalizeBundleType(doc.bundleType) ?? "cash",
     description: String(doc.description ?? ""),
+    features: strArrOrNull(doc.features) ?? [],
     durationDays: numOrNull(doc.durationDays),
     cashAmount: numOrNull(doc.cashAmount ?? doc.amount),
     starAmount: numOrNull(doc.starAmount ?? doc.numberOfstars),

--- a/mei-next/scripts/diagnose-reactions.ts
+++ b/mei-next/scripts/diagnose-reactions.ts
@@ -1,0 +1,70 @@
+/**
+ * READ-ONLY diagnostic for the reaction overwrite (409) bug.
+ * Inspects indexes + stored field BSON types on the `reactions` collection.
+ * Performs NO writes. Run: npx tsx scripts/diagnose-reactions.ts
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import mongoose from "mongoose";
+import { db } from "../lib/db";
+
+function loadEnvFiles(): void {
+  for (const name of [".env.local", ".env"]) {
+    const p = resolve(process.cwd(), name);
+    if (!existsSync(p)) continue;
+    for (const line of readFileSync(p, "utf8").split(/\r?\n/)) {
+      const m = /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*$/.exec(line);
+      if (!m) continue;
+      let v = m[2];
+      if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) v = v.slice(1, -1);
+      if (process.env[m[1]] === undefined) process.env[m[1]] = v;
+    }
+  }
+}
+
+function bsonType(v: unknown): string {
+  if (v === null) return "null";
+  if (v === undefined) return "undefined";
+  if (v instanceof mongoose.Types.ObjectId) return "ObjectId";
+  return typeof v;
+}
+
+async function main(): Promise<void> {
+  loadEnvFiles();
+  const conn = await db();
+  const coll = conn.connection.collection("reactions");
+
+  console.log("=== INDEXES on 'reactions' ===");
+  const indexes = await coll.indexes();
+  for (const ix of indexes) {
+    console.log(JSON.stringify({ name: ix.name, key: ix.key, unique: ix.unique ?? false, collation: ix.collation?.locale ?? null }));
+  }
+
+  const total = await coll.countDocuments({});
+  console.log(`\n=== total reactions: ${total} ===`);
+
+  console.log("\n=== field BSON types (sample up to 10 docs) ===");
+  const docs = await coll.find({}).limit(10).toArray();
+  for (const d of docs) {
+    console.log(
+      `userId=${bsonType(d.userId)} authorRoomId=${bsonType(d.authorRoomId)} reaction=${bsonType(d.reaction)} _id=${bsonType(d._id)}`,
+    );
+  }
+
+  // Count how many docs store userId / authorRoomId as ObjectId vs string.
+  const asObjId = await coll.countDocuments({ userId: { $type: "objectId" } });
+  const roomAsObjId = await coll.countDocuments({ authorRoomId: { $type: "objectId" } });
+  const userAsStr = await coll.countDocuments({ userId: { $type: "string" } });
+  const roomAsStr = await coll.countDocuments({ authorRoomId: { $type: "string" } });
+  console.log(`\n=== type breakdown ===`);
+  console.log(`userId:       string=${userAsStr}  objectId=${asObjId}`);
+  console.log(`authorRoomId: string=${roomAsStr}  objectId=${roomAsObjId}`);
+
+  await mongoose.disconnect();
+  console.log("\n[diagnose-reactions] done (read-only, no writes)");
+}
+
+main().catch((err) => {
+  console.error("[diagnose-reactions] fatal:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
Add a `features: string[]` field alongside `description` so the frontend can render bundle features as list items (issue #23). Wired through the model, serializer (PaymentBundlesOut + PricingBundleOut), create/update routes, service layer, and OpenAPI schemas. Legacy bundles serialize as `features: []`, preserving backward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payment bundles can now include optional feature lists.
  * Administrators can add or update bundle features when managing payment bundles.
  * Feature lists are preserved and displayed in payment and pricing information.
  * Existing bundles without features remain supported and show an empty feature list.
* **Documentation**
  * Payment bundle API schemas now document feature lists for creation, updates, and responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->