### PR TITLE
fix(cors): disable trailing-slash 308 redirect so CORS headers survive

### DIFF
--- a/mei-next/next.config.ts
+++ b/mei-next/next.config.ts
@@ -1,7 +1,18 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // The frontend (and the legacy FastAPI contract) calls every endpoint WITH a
+  // trailing slash, e.g. `GET /api/v2/author_room/`. By default Next.js answers
+  // such a request with a 308 trailing-slash redirect — and that redirect is
+  // emitted by the routing layer, so `proxy.ts` never attaches CORS headers to
+  // it. A cross-origin browser then fails the CORS preflight/redirect check
+  // before the real request is ever sent, surfacing as a "CORS error" / failed
+  // (≈500) request even though auth and the handler are fine.
+  //
+  // Disabling the redirect makes the trailing-slash path resolve to the same
+  // route handler directly, so `proxy.ts` can add CORS headers to the actual
+  // response (preflight + GET alike). See NovelBackend issue #23.
+  skipTrailingSlashRedirect: true,
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Problem (issue #23)
The frontend calls endpoints **with a trailing slash** (e.g. `GET /api/v2/author_room/`). Next.js answered with a **308 trailing-slash redirect emitted by the routing layer**, which `proxy.ts` cannot attach CORS headers to. Cross-origin browsers fail the CORS preflight/redirect check before the real request is sent — surfacing as a "CORS error" / failed (~500) request regardless of auth.

Confirmed against the deployed app (`novel-backend-beta.vercel.app`):
- `GET /api/v2/author_room/` + Origin → **308, no CORS headers**
- `OPTIONS /api/v2/author_room/` (preflight) + Origin → **308, no CORS headers**
- `GET /api/v2/author_room` (no slash) → 403 **with** full CORS headers

## Fix
Enable `skipTrailingSlashRedirect` in `next.config.ts`. Trailing-slash paths now resolve to the same route handler directly, so `proxy.ts` adds CORS headers to both the OPTIONS preflight and the actual response.

## Verification (local)
- `GET /api/v2/author_room/` + Origin → **403 + full CORS headers** ✅
- `OPTIONS /api/v2/author_room/` + Origin → **200 + full CORS headers** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)